### PR TITLE
Add option to group by common set of stack frame return addresses

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -186,8 +186,7 @@ func (t *Timeline) InputHandler() func(event *tcell.EventKey, setFocus func(p tv
 			case tcell.KeyEnter, tcell.KeyRight:
 				t.depth = 1
 				t.currentNumIx = 0
-				gr := t.timeline[t.groupIx][t.currentNumIx]
-				t.Highlight(fmt.Sprintf("num:%d", gr.Num))
+				t.highlight()
 				t.ScrollToHighlight()
 			}
 		} else {
@@ -227,8 +226,7 @@ func (t *Timeline) MouseHandler() func(action tview.MouseAction, event *tcell.Ev
 			t.depth = 1
 			if t.currentNumIx == -1 {
 				t.currentNumIx = 0
-				gr := t.timeline[t.groupIx][t.currentNumIx]
-				t.Highlight(fmt.Sprintf("num:%d", gr.Num))
+				t.highlight()
 				t.ScrollToHighlight()
 			}
 		}


### PR DESCRIPTION
Add "group by return addresses" (any ideas for better terminology?).
This means if stack traces have identical sets of file:line, we put them
in the same group. The idea is to deduplicate stack traces that follow
the exact same code path.